### PR TITLE
Fix SIGABRT crash from uncaught NSException in debug logger

### DIFF
--- a/swift-app/Late No More/globalFile.swift
+++ b/swift-app/Late No More/globalFile.swift
@@ -169,16 +169,19 @@ var DebugLogsURL:URL!
 class Log: TextOutputStream {
     
     func write(_ string: String) {
-        //        let fm = FileManager.default
-        
-        if let log = DebugLogsURL{//fm.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("Debug_Logs.txt")
-            if let handle = try? FileHandle(forWritingTo: log) {
-                handle.seekToEndOfFile()
-                handle.write(string.data(using: .utf8)!)
-                handle.closeFile()
-            } else {
-                try? string.data(using: .utf8)?.write(to: log)
-            }
+        guard let log = DebugLogsURL, let data = string.data(using: .utf8) else { return }
+
+        // The legacy FileHandle APIs (seekToEndOfFile/write(_:)/closeFile) raise
+        // Objective-C NSExceptions on I/O failure, which Swift cannot catch — a
+        // single bad write from the logging timer would abort the whole app.
+        // The throwing variants surface catchable Swift errors instead.
+        do {
+            let handle = try FileHandle(forWritingTo: log)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+        } catch {
+            try? data.write(to: log)
         }
     }
     static var log: Log = Log()


### PR DESCRIPTION
## Problem

Late No More has been crashing on-device with `EXC_CRASH (SIGABRT)` — the "Late No More quit unexpectedly" dialog. Two diagnostic reports on this machine (2026-07-22 **15:20** and **16:06**, build 28 / v2.0) share the exact same signature:

```
__NSFireTimer
 -> print(..., to: &Log.log)          (globalFile.swift addLog)
 -> Log.write                          (TextOutputStream)
 -> -[NSConcreteFileHandle writeData:]  <-- throws NSException
 -> __cxa_rethrow -> abort()            (SIGABRT)
```

## Root cause

`Log.write` (`globalFile.swift`) used the **legacy** `FileHandle` APIs:

```swift
handle.seekToEndOfFile()
handle.write(string.data(using: .utf8)!)
handle.closeFile()
```

These raise **Objective-C `NSException`s** on any I/O failure (bad file descriptor, disk full, sandbox denial, etc.). Swift **cannot** catch ObjC exceptions with `try?` / `do-catch`, so the existing `try?` gave no protection — a single failed write from the recurring logging timer aborted the entire app. Because logging is timer-driven, once the handle goes bad it crashes reliably.

## Fix

Switch to the modern **throwing** `FileHandle` variants (`seekToEnd()`, `write(contentsOf:)`, `close()`) inside a `do/catch`. These surface catchable **Swift** errors, so a failed write is handled gracefully (falls back to `data.write(to:)`) instead of crashing.

## Verification

- Extracted the `Log` class into a standalone Swift program and compiled with `swiftc` (the full Xcode build needs the `Sparkle.framework` module, which isn't checked into the repo).
- Confirmed normal writes still append correctly to the log file.
- Confirmed that pointing the logger at an **unwritable path no longer crashes** — the pre-fix code aborts via the uncaught `NSException` at exactly this point; the fixed code catches it and continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)