### PR TITLE
Add Sentry crash reporting to the macOS app

### DIFF
--- a/swift-app/Late No More.xcodeproj/project.pbxproj
+++ b/swift-app/Late No More.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		8F6B66B52A0233B3002B8137 /* onboardingCardsVc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6B66B42A0233B3002B8137 /* onboardingCardsVc.swift */; };
 		8F6B66B62A023D66002B8137 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F6B66B02A022801002B8137 /* Sparkle.framework */; };
 		8F6B66B72A023D66002B8137 /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8F6B66B02A022801002B8137 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5E570C0A0000000000000003 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 5E570C0A0000000000000002 /* Sentry */; };
 		8F71395429F64CF80070C44D /* voiceOptionsVc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F71395329F64CF80070C44D /* voiceOptionsVc.swift */; };
 		8F71395629F690770070C44D /* advancedSettingsVc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F71395529F690770070C44D /* advancedSettingsVc.swift */; };
 		8F71395829F6991A0070C44D /* barkPoolVc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F71395729F6991A0070C44D /* barkPoolVc.swift */; };
@@ -108,6 +109,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5E570C0A0000000000000003 /* Sentry in Frameworks */,
 				8F6B66B62A023D66002B8137 /* Sparkle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -215,6 +217,9 @@
 			dependencies = (
 			);
 			name = "Late No More";
+			packageProductDependencies = (
+				5E570C0A0000000000000002 /* Sentry */,
+			);
 			productName = "Late No More";
 			productReference = 8F79699F29518A8000188F5D /* Late No More.app */;
 			productType = "com.apple.product-type.application";
@@ -244,6 +249,9 @@
 				Base,
 			);
 			mainGroup = 8F79699629518A8000188F5D;
+			packageReferences = (
+				5E570C0A0000000000000001 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+			);
 			productRefGroup = 8F7969A029518A8000188F5D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -527,6 +535,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		5E570C0A0000000000000001 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		5E570C0A0000000000000002 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5E570C0A0000000000000001 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 8F79699729518A8000188F5D /* Project object */;
 }

--- a/swift-app/Late No More.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift-app/Late No More.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "a72b37d142139a9f8de021ec1a2d4e7ec2a7ffc9ebc87493f58bac80a85691cb",
+  "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "f196cbb98e0388381d57908f2f5a9bdc385cde68",
+        "version" : "8.58.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/swift-app/Late No More/AppDelegate.swift
+++ b/swift-app/Late No More/AppDelegate.swift
@@ -8,14 +8,26 @@
 import Cocoa
 import EventKit
 import Sparkle
+import Sentry
+
+// Client DSN for the Late No More Sentry project. Client DSNs are safe to
+// ship in the app — they only permit sending events, not reading them.
+private let sentryDSN = "https://46bcd71ab3fb9cae3c8bc470bac8c6b2@o4509122919006208.ingest.us.sentry.io/4511782954336256"
 
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBOutlet weak var menuItemCheckForUpdates: NSMenuItem!
     var updater: SUUpdater?
-    
+
     func applicationWillFinishLaunching(_ notification: Notification) {
+        SentrySDK.start { options in
+            options.dsn = sentryDSN
+            options.releaseName = Bundle.main.releaseVersionNumber.map { version in
+                "com.focusbear.latenomore@\(version)+\(Bundle.main.buildVersionNumber ?? "")"
+            }
+        }
+
         let settingForScreeenTimeFilePath = "/Users/\(NSUserName())/Library/Application Support/com.App.EarnYourScreentime/fbtt.plist"
         settingForScreeenTimeFileURL = URL(fileURLWithPath: settingForScreeenTimeFilePath)
         let bundel = Bundle.main.bundleIdentifier ?? ""


### PR DESCRIPTION
## Why

Late No More has been crashing on users' machines (`EXC_CRASH` / `SIGABRT`) with **no visibility** — the only signal today is local `.ips` diagnostic reports on the affected machine. This wires up automatic crash/error reporting so we actually find out when the app dies.

(The specific crash that prompted this is fixed separately in #35 — an uncaught `NSException` in the debug logger. Sentry would have surfaced it automatically.)

## What

- Add [`getsentry/sentry-cocoa`](https://github.com/getsentry/sentry-cocoa) (8.x, resolved to **8.58.4**) as a **Swift Package Manager** dependency; link and embed the `Sentry` product.
- Initialise `SentrySDK` as the **very first statement** in `applicationWillFinishLaunching(_:)` so even early-launch crashes are captured. Each event is tagged with the app release (`com.focusbear.latenomore@<version>+<build>`).
- Commit the pinned `Package.resolved`.

The DSN is a **client DSN** — safe to ship in the app (it only permits *sending* events, not reading them), so it lives in a named constant in `AppDelegate.swift`.

## Verification

- `xcodebuild` Debug / arm64 / Xcode 26.3: **BUILD SUCCEEDED**, `-framework Sentry` linked, `Sentry.framework` embedded in `Late No More.app/Contents/Frameworks/`.
- Launched the built binary: it runs **past** `SentrySDK.start` into normal startup (calendar setup) with no dyld "Symbol not found" error — confirming the SDK is linked and callable at runtime.
- End-to-end (event appears in the Sentry dashboard) should be confirmed on the Sentry side, e.g. via a test event after this merges into a signed build.

> Note for reviewers: the repo doesn't check in `Sparkle.framework` (it's resolved out-of-band by the existing build process), so a local build needs that framework present at `$(PROJECT_DIR)` as usual. Nothing about that changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)