### PR TITLE
Fix verbal alerts firing outside configured hours

### DIFF
--- a/swift-app/Late No More/EventWarningManager.swift
+++ b/swift-app/Late No More/EventWarningManager.swift
@@ -90,9 +90,19 @@ class EventWarningManager {
         
         let startDateTime = combineCurrentDateWithTime(from: pickerStartTimeDateValue)
         let endDateTime = combineCurrentDateWithTime(from: pickerEndTimeDateValue)
-        
-        let events = calendarManager.fetchEvents(from: startDateTime, to: endDateTime, in: calendarsToCheck)
         let currentDate = Date()
+
+        // The Start/End pickers define the hours the user wants verbal alerts.
+        // Gate on the current wall-clock time here: without this, an event that
+        // merely overlaps the fetch window (e.g. one running 5:55–6:25am against a
+        // 6:00am start) gets fetched and its 15-minute pre-alert fires before the
+        // window opens — waking the user outside their chosen hours.
+        guard isWithinAlertHours(currentDate, start: startDateTime, end: endDateTime) else {
+            addLog(text: "func:- checkEvents skipped, current time outside verbal alert hours")
+            return
+        }
+
+        let events = calendarManager.fetchEvents(from: startDateTime, to: endDateTime, in: calendarsToCheck)
         
         for event in events where !event.isAllDay {
             if let startDateTime = event.startDate{
@@ -134,6 +144,14 @@ class EventWarningManager {
         
     }
     
+    private func isWithinAlertHours(_ now: Date, start: Date, end: Date) -> Bool {
+        if start <= end {
+            return now >= start && now <= end
+        }
+        // Overnight window (e.g. 22:00–06:00): inside if before end or after start.
+        return now >= start || now <= end
+    }
+
     private func combineCurrentDateWithTime(from time: Date) -> Date {
         let calendar = Calendar.current
         let dateComponents = calendar.dateComponents([.year, .month, .day], from: Date())


### PR DESCRIPTION
## Problem

A user was woken by a verbal alert at **5:40am** despite configuring **Start Time 6:00am / End Time 7:00pm** under *"What hours do you want to get verbal alerts?"*.

The Start/End time pickers were only ever used as the **calendar fetch window** — nothing gated the actual alert on the **current wall-clock time**. Two compounding issues:

1. `EventWarningManager.checkEvents()` never checked whether `Date()` was inside the configured `[start, end]` window before firing.
2. EventKit's `predicateForEvents(withStart:end:)` returns events that **overlap** the window. So a meeting running e.g. **5:55–6:25am** overlaps the `[6:00am, 7:00pm]` fetch window, gets fetched, and its **15-minute pre-alert fires at ~5:40am** — outside the user's chosen hours.

## Fix

Gate `checkEvents()` on the current time being within the configured `[start, end]` window before fetching/alerting. Added a small `isWithinAlertHours(_:start:end:)` helper that also handles an overnight window (e.g. 22:00–06:00).

```swift
guard isWithinAlertHours(currentDate, start: startDateTime, end: endDateTime) else {
    addLog(text: "func:- checkEvents skipped, current time outside verbal alert hours")
    return
}
```

## Verification

- `xcrun swiftc -parse` on the changed file passes (no syntax errors).
- A full `xcodebuild` is currently blocked on this checkout by a pre-existing, unrelated `Sparkle.framework` reference not present at the project root (only inside the packaged `.app` artifact) — not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)